### PR TITLE
Add query support for <a> tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,10 +32,10 @@ function overrideMethod() {
       method = body._method.toUpperCase();
     }
 
-    // params support
-    var params = this.params;
-    if (params && params._method) {
-      method = body._method.toUpperCase();
+    // query support
+    var query = this.request.query;
+    if (query && query._method) {
+      method = query._method.toUpperCase();
     }
 
     // header support

--- a/index.js
+++ b/index.js
@@ -32,6 +32,12 @@ function overrideMethod() {
       method = body._method.toUpperCase();
     }
 
+    // params support
+    var params = this.params;
+    if (params && params._method) {
+      method = body._method.toUpperCase();
+    }
+
     // header support
     var header = this.get('x-http-method-override');
     if (header) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -72,6 +72,31 @@ describe('override method middleware', function () {
     .expect(200, done);
   });
 
+  it('should override with query._method', function (done) {
+    var app = koa();
+    app.use(bodyParser());
+    app.use(override());
+    app.use(function* () {
+      console.log(this.request.query)
+      this.body = {
+        method: this.method,
+        url: this.url,
+        query: this.request.query
+      };
+    });
+
+    request(app.listen())
+        .get('/foo?_method=delete')
+        .expect({
+          method: 'DELETE',
+          url: '/foo?_method=delete',
+          query: {
+            _method: 'delete'
+          }
+        })
+        .expect(200, done);
+  });
+
   it('should throw invalid overriden method error', function (done) {
     var app = koa();
     app.on('error', function (err) {


### PR DESCRIPTION
Add query support, which enables method-overriding for the following example:

<a href="http://localhost:3000/blablabla?_method=PUT"

Note: Although there might be conflict between body & query since both can include the "_method" key, such scenario can be easily avoided.

Signed-off-by: HeavenDuke liuhancheng@shangxiane.com
